### PR TITLE
chore: add devcontainer + helpers (Codespace-ready)

### DIFF
--- a/.devcontainer/create_pr.ps1
+++ b/.devcontainer/create_pr.ps1
@@ -1,0 +1,44 @@
+param(
+    [string]$Branch = "",
+    [string]$Message = "chore: add devcontainer files",
+    [string]$Title = "",
+    [switch]$Draft
+)
+
+function Show-Usage {
+    @"
+Usage: .\create_pr.ps1 [-Branch <name>] [-Message <commit message>] [-Title <PR title>] [-Draft]
+
+Helper to create a branch, commit changes (if any), push, and open a draft PR using gh.
+"@
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error "gh (GitHub CLI) is required. Please install and authenticate gh before running this script."
+    exit 2
+}
+
+if (-not $Branch -or $Branch -eq "") {
+    $Branch = "pr/devcontainer-$(Get-Date -Format yyyyMMdd-HHmmss)"
+}
+
+if (-not $Title -or $Title -eq "") {
+    $Title = $Message
+}
+
+if ((git status --porcelain) -ne "") {
+    Write-Host "There are local changes. These will be committed with message: $Message"
+    git add -A
+    git commit -m $Message
+} else {
+    Write-Host "No local changes to commit. Creating branch from current HEAD."
+}
+
+git checkout -b $Branch
+git push -u origin $Branch
+
+$prArgs = @("pr", "create", "--title", $Title, "--body-file", ".pr_body.md")
+if ($Draft) { $prArgs += "--draft" }
+
+Write-Host "Running: gh $($prArgs -join ' ')"
+gh @prArgs

--- a/.devcontainer/create_pr.sh
+++ b/.devcontainer/create_pr.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: create_pr.sh [-b branch-name] [-m commit-message] [-t title] [-d]
+
+Helper to create a branch, commit changes (if any), push, and open a draft PR using gh.
+
+Options:
+  -b BRANCH    Branch name to create (default: pr/devcontainer-<timestamp>)
+  -m MESSAGE   Commit message if committing staged changes (default: "chore: add devcontainer files")
+  -t TITLE     PR title (default: same as commit message)
+  -d           Create the PR as draft (default: on)
+  -h           Show this help
+USAGE
+}
+
+BRANCH=""
+MSG="chore: add devcontainer files"
+TITLE=""
+DRAFT=true
+
+while getopts ":b:m:t:dh" opt; do
+  case ${opt} in
+    b) BRANCH=${OPTARG} ;;
+    m) MSG=${OPTARG} ;;
+    t) TITLE=${OPTARG} ;;
+    d) DRAFT=true ;;
+    h) usage; exit 0 ;;
+    :) echo "Error: -${OPTARG} requires an argument" >&2; usage; exit 1 ;;
+    \?) echo "Invalid option: -${OPTARG}" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "$BRANCH" ]; then
+  BRANCH="pr/devcontainer-$(date +%Y%m%d-%H%M%S)"
+fi
+
+if [ -z "$TITLE" ]; then
+  TITLE="$MSG"
+fi
+
+echo "Preparing to create branch '$BRANCH' and push changes"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh (GitHub CLI) is required to create the draft PR. Please install and authenticate 'gh' first." >&2
+  exit 2
+fi
+
+# Make sure we're on a clean working tree or that user intends to commit
+if ! git diff --quiet || ! git diff --quiet --staged; then
+  echo "There are local changes. These will be committed with message: $MSG"
+  git add -A
+  git commit -m "$MSG"
+else
+  echo "No local changes to commit. Creating branch from current HEAD."
+fi
+
+git checkout -b "$BRANCH"
+git push -u origin "$BRANCH"
+
+PR_CMD=(gh pr create --title "$TITLE" --body-file .pr_body.md)
+if [ "$DRAFT" = true ]; then
+  PR_CMD+=(--draft)
+fi
+
+echo "Running: ${PR_CMD[*]}"
+"${PR_CMD[@]}"
+
+echo "PR created. Visit the repository in your browser to review or continue working." 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,14 @@
       "extensions": [
         "ms-dotnettools.csharp",
         "ms-python.python",
-        "github.vscode-pull-request-github"
+        "ms-python.vscode-pylance",
+        "ms-vscode.powershell",
+        "eamodio.gitlens",
+        "github.vscode-pull-request-github",
+        "redhat.vscode-yaml",
+        "davidanson.vscode-markdownlint",
+        "ms-azuretools.vscode-docker",
+        "esbenp.prettier-vscode"
       ]
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "P100 Electrical Agent Suite",
+  "image": "mcr.microsoft.com/devcontainers/dotnet:8.0",
+  "remoteUser": "vscode",
+  "features": {},
+  "postCreateCommand": "./.devcontainer/postCreate.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-dotnettools.csharp",
+        "ms-python.python",
+        "github.vscode-pull-request-github"
+      ]
+    }
+  }
+}

--- a/.devcontainer/postCreate.ps1
+++ b/.devcontainer/postCreate.ps1
@@ -1,0 +1,74 @@
+#!/usr/bin/env pwsh
+Set-StrictMode -Version Latest
+
+Write-Host "Running PowerShell postCreate: installing pac, pwsh checks, and optional Python 3.11"
+
+function Install-PacIfMissing {
+    if (Get-Command pac -ErrorAction SilentlyContinue) {
+        Write-Host "pac already installed at $(Get-Command pac)."
+        return
+    }
+    if (Get-Command dotnet -ErrorAction SilentlyContinue) {
+        Write-Host "Installing pac via dotnet tool (user-local)"
+        try {
+            dotnet tool install --global Microsoft.PowerApps.CLI.Tool -ErrorAction Stop
+        } catch {
+            Write-Warning "dotnet tool install failed; attempting update"
+            dotnet tool update --global Microsoft.PowerApps.CLI.Tool -ErrorAction SilentlyContinue
+        }
+        $env:PATH = "$env:USERPROFILE/.dotnet/tools;$env:PATH"
+    } else {
+        Write-Warning "dotnet not found; cannot install pac automatically"
+    }
+}
+
+function Install-PwshIfMissing {
+    if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+        Write-Host "pwsh present at $(Get-Command pwsh)."
+        return
+    }
+    if (Get-Command apt-get -ErrorAction SilentlyContinue) {
+        Write-Host "Detected apt-get. Attempting to install pwsh via apt"
+        try {
+            $tmp = "/tmp/packages-microsoft-prod.deb"
+            Invoke-WebRequest -Uri "https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb" -OutFile $tmp -UseBasicParsing -ErrorAction Stop
+            sudo dpkg -i $tmp
+            sudo apt-get update -y
+            sudo apt-get install -y powershell
+        } catch {
+            Write-Warning "pwsh install failed: $_"
+        }
+    } else {
+        Write-Host "No apt-get found; skipping pwsh install."
+    }
+}
+
+function Install-Python311IfMissing {
+    if (Get-Command python3.11 -ErrorAction SilentlyContinue) {
+        Write-Host "python3.11 already present: $(python3.11 --version)"
+        return
+    }
+    if (Get-Command apt-get -ErrorAction SilentlyContinue) {
+        Write-Host "Detected apt-get. Installing python3.11..."
+        try {
+            sudo apt-get update -y
+            sudo apt-get install -y software-properties-common || true
+            sudo apt-get install -y python3.11 python3.11-venv python3.11-distutils || true
+            # ensure pip
+            if (-not (python3.11 -m pip --version -ErrorAction SilentlyContinue)) {
+                Invoke-WebRequest -Uri "https://bootstrap.pypa.io/get-pip.py" -OutFile "/tmp/get-pip.py" -UseBasicParsing -ErrorAction Stop
+                sudo python3.11 /tmp/get-pip.py
+            }
+        } catch {
+            Write-Warning "python3.11 install failed: $_"
+        }
+    } else {
+        Write-Host "No apt-get found; skipping python3.11 install."
+    }
+}
+
+Install-PacIfMissing
+Install-PwshIfMissing
+Install-Python311IfMissing
+
+Write-Host "Post-create PowerShell tasks complete. Next steps: activate venv, install requirements, and use create_pr.ps1 for PRs."

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running devcontainer postCreate: installing Power Platform CLI (pac) safely"
+
+# Use a local temp folder to download/install without touching global state unnecessarily
+TMP_DIR="/tmp/p100-devcontainer-setup"
+mkdir -p "$TMP_DIR"
+cd "$TMP_DIR"
+
+if command -v pac >/dev/null 2>&1; then
+  echo "pac already installed at $(command -v pac). Skipping pac install."
+else
+  echo "Installing Pac CLI via dotnet tool (user-local). This requires dotnet to be available in the image."
+  # install to the user-level tool path
+  if dotnet --version >/dev/null 2>&1; then
+    dotnet tool install --global Microsoft.PowerApps.CLI.Tool || {
+      echo "dotnet tool install failed; attempting to update and retry"
+      dotnet tool update --global Microsoft.PowerApps.CLI.Tool || true
+    }
+    # Ensure ~/.dotnet/tools is on PATH for the remainder of the script and instruct the user
+    export PATH="$HOME/.dotnet/tools:$PATH"
+  else
+    echo "dotnet not found in the container image. Please install dotnet or use an image with dotnet preinstalled."
+    exit 1
+  fi
+fi
+
+echo "Verifying pac installation..."
+if pac --version >/dev/null 2>&1; then
+  echo "pac is installed: $(pac --version)"
+else
+  echo "pac not found after installation attempt. Check the logs above."
+fi
+
+echo "Post-create tasks complete. Next steps:"
+echo " - Open a terminal in the Codespace (or container) and run:"
+echo "     git checkout -b my-codespace-branch"
+echo "     ./.devcontainer/create_pr.sh --help   # to see the helper options for creating a draft PR"
+echo " - If you need Python dependencies for the 'mcp' service, run:"
+echo "     python -m pip install -r github_app/requirements.txt"
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,45 @@
+# Python virtualenvs
+.mcp_venv/
+.venv/
+venv/
+env/
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Python cache and compiled files
+__pycache__/
+*.py[cod]
+*.pyo
+
+# IDE/editor
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+
+# Coverage
+htmlcov/
+
+# Environment files
+.env
+
+# Local PR body / temp
+.pr_body.md
+
+# Archive and temp directories
+_temp/
+temp/
+
+# Wheelhouse
+wheelhouse/
+
+# Notebook checkpoints
+.ipynb_checkpoints/
 # -----------------------
 # Power Platform / PAC / Repo structure
 # -----------------------

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ htmlcov/
 .env
 
 # Local PR body / temp
-.pr_body.md
+# .pr_body.md  (tracked intentionally; remove this comment if you want to ignore it)
 
 # Archive and temp directories
 _temp/

--- a/.pr_body.md
+++ b/.pr_body.md
@@ -1,0 +1,75 @@
+This draft PR adds a reproducible Codespace configuration to the repository.
+
+Files added:
+
+- `.devcontainer/devcontainer.json` — devcontainer configuration using dotnet 8 image.
+- `.devcontainer/postCreate.sh` — idempotent post-create script that installs the Power Platform CLI (pac) using dotnet tools and prints next steps.
+- `.devcontainer/create_pr.sh` — helper script to create a branch and draft PR using the GitHub CLI (`gh`).
+
+Notes for reviewers:
+
+- The devcontainer image is intentionally minimal (dotnet 8) to support the Power Platform CLI install. If you prefer a different base image (python, node), suggest alternatives in the review.
+- The postCreate script installs pac to the user tool path and ensures PATH is set for the current session. It will skip installation if pac is already present.
+- The create_pr helper will commit any local changes and create a draft PR using `gh`. It intentionally requires the user to run it inside the Codespace or a machine with `gh` authenticated.
+
+How to test locally (recommended):
+
+1. Open Codespace from this branch.
+2. Let devcontainer build and run postCreate.
+3. Open a terminal and run `pac --version` to confirm the CLI is available.
+Short summary:
+
+This branch adds initial MCP server scaffold, GitHub workflows to run tests and label indexing, helper scripts for label management, and documentation/artifacts used to generate labels. It also includes a short chat-summary note under docs/chat-summaries to capture a recent assistant interaction.
+
+Key files added (high level):
+- .github/workflows/labels-index.yml
+- .github/workflows/mcp-tests.yml
+- mcp/ (Dockerfile, app, tests, README, requirements)
+- scripts/propose_labels_pr.py, scripts/seed-labels.ps1
+- docs/GitHub/Colour_Labels_GitHub.xlsx
+- docs/chat-summaries/2025-09-25-haywire-summary.md
+
+Notes:
+- No production-sensitive secrets are included. The MCP server is a local/dev scaffold intended for testing and documentation.
+
+Full chat-summary note (from docs/chat-summaries/2025-09-25-haywire-summary.md):
+
+---
+title: "Chat summary — assistant went haywire"
+date: 2025-09-25
+branch: fix/designandcosting-bootstrap
+repo: electricgltd/P100-Electrical-Agent-Suite
+---
+
+# Chat summary — assistant went haywire
+
+Summary:
+
+- The assistant's previous responses became overly verbose and focused on internal tool/process policies rather than giving concise, actionable guidance.
+- The user asked for a short, clear summary to capture the interaction for project records.
+
+What happened:
+
+- The conversation included long policy/tool instructions (patch formats, tool usage, code-editing rules).
+- This caused confusion and no effective changes or fixes were applied to the codebase as part of that exchange.
+
+Impact:
+
+- Minor wasted time and confusion.
+- No code changes or sensitive data exposure detected.
+
+Actions taken:
+
+- User requested a compact summary for the project notebook.
+- Assistant produced a concise summary and a copy-paste-ready notebook entry.
+
+Outcome:
+
+- Notebook entry created. No repo edits performed besides adding this summary file.
+
+Next steps:
+
+- Paste this entry into the chosen project notebook if you prefer it in a different file, or keep this file under `docs/chat-summaries/` for historical records.
+- If desired, ask the assistant to append this entry to an existing file (specify file path) or to produce a shorter/longer variant.
+
+Tags: chat-summary, assistant-behavior, housekeeping

--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Parent/child Copilot Studio agents for an NICEIC electrical contractor:
 - `/env` – WinGet configuration and local-only samples
 
 > **Public-safety**: no secrets are stored in this repo. Use **GitHub Secrets** and local `.env` files (excluded by `.gitignore`).
+
+## Local Git GUI recommendation
+
+If you prefer a powerful desktop GUI for repository operations, GitKraken is a good option — it provides an intuitive commit graph, interactive rebases, conflict resolution UI, and easy remote integrations. For in-container development and PR workflows we recommend using VS Code with the GitLens and GitHub Pull Requests extensions (both are included in the devcontainer configuration).
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "p100-electrical-agent-suite"
+version = "0.0.0"
+description = "P100 Electrical Agent Suite — collection of Copilot agents and tools for electrical projects"
+readme = "README.md"
+authors = [ { name = "electricgltd" } ]
+license = "MIT"
+requires-python = ">=3.8"
+keywords = ["copilot", "agent", "electrical", "p100"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Operating System :: OS Independent",
+]
+
+[project.urls]
+Homepage = "https://github.com/electricgltd/P100-Electrical-Agent-Suite"
+Repository = "https://github.com/electricgltd/P100-Electrical-Agent-Suite"
+
+[tool.setuptools.packages.find]
+where = ["github_app"]
+include = ["github_app*"]


### PR DESCRIPTION
This draft PR adds a reproducible Codespace configuration to the repository.

Files added:

- `.devcontainer/devcontainer.json` — devcontainer configuration using dotnet 8 image.
- `.devcontainer/postCreate.sh` — idempotent post-create script that installs the Power Platform CLI (pac) using dotnet tools and prints next steps.
- `.devcontainer/create_pr.sh` — helper script to create a branch and draft PR using the GitHub CLI (`gh`).

Notes for reviewers:

- The devcontainer image is intentionally minimal (dotnet 8) to support the Power Platform CLI install. If you prefer a different base image (python, node), suggest alternatives in the review.
- The postCreate script installs pac to the user tool path and ensures PATH is set for the current session. It will skip installation if pac is already present.
- The create_pr helper will commit any local changes and create a draft PR using `gh`. It intentionally requires the user to run it inside the Codespace or a machine with `gh` authenticated.

How to test locally (recommended):

1. Open Codespace from this branch.
2. Let devcontainer build and run postCreate.
3. Open a terminal and run `pac --version` to confirm the CLI is available.
Short summary:

This branch adds initial MCP server scaffold, GitHub workflows to run tests and label indexing, helper scripts for label management, and documentation/artifacts used to generate labels. It also includes a short chat-summary note under docs/chat-summaries to capture a recent assistant interaction.

Key files added (high level):
- .github/workflows/labels-index.yml
- .github/workflows/mcp-tests.yml
- mcp/ (Dockerfile, app, tests, README, requirements)
- scripts/propose_labels_pr.py, scripts/seed-labels.ps1
- docs/GitHub/Colour_Labels_GitHub.xlsx
- docs/chat-summaries/2025-09-25-haywire-summary.md

Notes:
- No production-sensitive secrets are included. The MCP server is a local/dev scaffold intended for testing and documentation.

Full chat-summary note (from docs/chat-summaries/2025-09-25-haywire-summary.md):

---
title: "Chat summary — assistant went haywire"
date: 2025-09-25
branch: fix/designandcosting-bootstrap
repo: electricgltd/P100-Electrical-Agent-Suite
---

# Chat summary — assistant went haywire

Summary:

- The assistant's previous responses became overly verbose and focused on internal tool/process policies rather than giving concise, actionable guidance.
- The user asked for a short, clear summary to capture the interaction for project records.

What happened:

- The conversation included long policy/tool instructions (patch formats, tool usage, code-editing rules).
- This caused confusion and no effective changes or fixes were applied to the codebase as part of that exchange.

Impact:

- Minor wasted time and confusion.
- No code changes or sensitive data exposure detected.

Actions taken:

- User requested a compact summary for the project notebook.
- Assistant produced a concise summary and a copy-paste-ready notebook entry.

Outcome:

- Notebook entry created. No repo edits performed besides adding this summary file.

Next steps:

- Paste this entry into the chosen project notebook if you prefer it in a different file, or keep this file under `docs/chat-summaries/` for historical records.
- If desired, ask the assistant to append this entry to an existing file (specify file path) or to produce a shorter/longer variant.

Tags: chat-summary, assistant-behavior, housekeeping
