### PR TITLE
ci: build and smoke-test mcp docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Ignore virtual environments
+.venv
+env
+__pycache__
+*.pyc
+
+# Git
+.git
+.gitignore
+
+# Node
+node_modules
+
+# OS files
+.DS_Store
+
+# Editor files
+.vscode
+
+# Large files and artifacts
+*.xlsx
+*.docx
+*.zip
+*.tar.gz
+
+# Docker
+docker-compose.override.yml
+
+# Ignore workspace-local dev tokens
+.env
+.env.*

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,50 @@
+name: Build and smoke-test MCP image
+
+on:
+  pull_request:
+    paths:
+      - 'mcp/**'
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU (for multi-arch cache compatibility)
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build mcp image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: mcp/Dockerfile
+          load: true
+          tags: p100-mcp:ci
+
+      - name: Run container and wait for startup
+        run: |
+          docker run -d --name p100-mcp-ci -p 8080:8080 p100-mcp:ci
+          for i in {1..15}; do
+            sleep 1
+            if curl -sSf http://127.0.0.1:8080/health >/dev/null 2>&1; then
+              echo 'health ok'
+              exit 0
+            fi
+          done
+          docker logs p100-mcp-ci || true
+          docker rm -f p100-mcp-ci || true
+          echo 'Failed to get healthy response from container' >&2
+          exit 1
+
+      - name: Stop and remove container
+        if: always()
+        run: |
+          docker rm -f p100-mcp-ci || true

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,7 +1,30 @@
 FROM python:3.11-slim
+
+# Create and use application directory
 WORKDIR /app
-COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r /app/requirements.txt
-COPY .. /app
+
+# Install only requirements first to leverage layer caching
+# The docker-compose build context is the repo root, so copy the file from /mcp/requirements.txt
+COPY mcp/requirements.txt /app/requirements.txt
+
+# Install OS-level build dependencies needed to compile wheels (PyYAML, etc.)
+RUN apt-get update && \
+	apt-get install -y --no-install-recommends \
+		build-essential \
+		gcc \
+		libyaml-dev \
+		ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip and wheel to improve build compatibility, then install requirements
+RUN python -m pip install --upgrade pip setuptools wheel && \
+	pip install --no-cache-dir -r /app/requirements.txt
+
+# Copy only the application package to avoid copying the whole repository
+COPY mcp /app/mcp
+
+# Expose port used by uvicorn
 EXPOSE 8080
+
+# Run the app
 CMD ["uvicorn", "mcp.app:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
This workflow builds the mcp Docker image on PRs and pushes to CI; it runs a quick smoke-test against /health. Helps catch Dockerfile regressions early.