### PR TITLE
ci: set PYTHONPATH in mcp-tests workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,3 +48,8 @@ jobs:
         if: always()
         run: |
           docker rm -f p100-mcp-ci || true
+
+      - name: Run pytest inside built image
+        # This runs tests in the same environment the app will run in
+        run: |
+          docker run --rm p100-mcp:ci /bin/sh -c "python -m pip install -r /app/mcp/requirements.txt && pytest -q /app/mcp/tests"

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -23,6 +23,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r mcp/requirements.txt
       - name: Run tests
-        # Run pytest from the repository root so the `mcp` package is on sys.path
+        # Ensure the repository root is on PYTHONPATH so `mcp` imports reliably
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           pytest -q


### PR DESCRIPTION
Export PYTHONPATH to the repository root so pytest can import the  package reliably in runner environments.