### PR TITLE
ci: allow insecure MCP dev token during tests

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -48,3 +48,8 @@ jobs:
         if: always()
         run: |
           docker rm -f p100-mcp-ci || true
+
+      - name: Run pytest inside built image
+        # This runs tests in the same environment the app will run in
+        run: |
+          docker run --rm p100-mcp:ci /bin/sh -c "python -m pip install -r /app/mcp/requirements.txt && pytest -q /app/mcp/tests"

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -23,6 +23,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r mcp/requirements.txt
       - name: Run tests
-        # Run pytest from the repository root so the `mcp` package is on sys.path
+        # Ensure the repository root is on PYTHONPATH so `mcp` imports reliably
+        env:
+          PYTHONPATH: ${{ github.workspace }}
         run: |
           pytest -q

--- a/.github/workflows/mcp-tests.yml
+++ b/.github/workflows/mcp-tests.yml
@@ -26,5 +26,7 @@ jobs:
         # Ensure the repository root is on PYTHONPATH so `mcp` imports reliably
         env:
           PYTHONPATH: ${{ github.workspace }}
+          # Allow the MCP dev server to accept the default 'dev-token' used by tests
+          MCP_DEV_ALLOW_INSECURE: 'true'
         run: |
           pytest -q


### PR DESCRIPTION
Set MCP_DEV_ALLOW_INSECURE=true in tests workflow so the dev-token used by tests ('dev-token') is accepted in CI environment.